### PR TITLE
Refactor for using map instead of array. Also some other small things.

### DIFF
--- a/simplerestapi/src/main/main.go
+++ b/simplerestapi/src/main/main.go
@@ -20,53 +20,64 @@ type Address struct {
 	State string `json:"state,omitempty"`
 }
 
-var people []Person
+// use map instead array.
+var people map[string]Person
 
-func GetPeople(w http.ResponseWriter, r *http.Request) {
+// this function doesn't need to be exported, so, can be lowercase.
+// also, i've renamed to people
+func all(w http.ResponseWriter, r *http.Request) {
 	json.NewEncoder(w).Encode(people)
 }
 
-func GetPerson(w http.ResponseWriter, r *http.Request) {
+// this function doesn't need to be exported, so, can be lowercase.
+// also, I've renamed to person
+func findByID(w http.ResponseWriter, r *http.Request) {
 	params := mux.Vars(r)
-	for _, item := range people {
-		if item.ID == params["id"] {
-			json.NewEncoder(w).Encode(item)
-			return
-		}
+	found, ok := people[params["id"]]
+	if ok {
+		json.NewEncoder(w).Encode(found)
+	} else {
+		http.Error(w, "Not found.", http.StatusNotFound)
 	}
-	json.NewEncoder(w).Encode(&Person{})
 }
 
-func CreatePerson(w http.ResponseWriter, r *http.Request) {
+// this function doesn't need to be exported, so, can be lowercase.
+// also, I've renamed to create
+func store(w http.ResponseWriter, r *http.Request) {
 	params := mux.Vars(r)
 	var person Person
-	_ = json.NewDecoder(r.Body).Decode(&person)
+	if err := json.NewDecoder(r.Body).Decode(&person); err != nil {
+		http.Error(w, "Error deserializing request body. I'm a teapot!", http.StatusTeapot)
+		return
+	}
 	person.ID = params["id"]
-	people = append(people, person)
-	json.NewEncoder(w).Encode(people)
+	people[params["id"]] = person
+	w.WriteHeader(http.StatusCreated)
 }
 
-func DeletePerson(w http.ResponseWriter, r *http.Request) {
+// this function doesn't need to be exported, so, can be lowercase.
+// also, I've renamed to delete
+func remove(w http.ResponseWriter, r *http.Request) {
 	params := mux.Vars(r)
-	for index, item := range people {
-		if item.ID == params["id"] {
-			people = append(people[:index], people[:index+1]...)
-			break
-		}
-	}
-	json.NewEncoder(w).Encode(people)
+	id := params["id"]
+	delete(people, id)
+	w.WriteHeader(http.StatusNoContent)
 }
 
 func main() {
-	people = append(people, Person{ID: "1", Firstname: "John", Lastname: "Doe", Address: &Address{City: "City X", State: "State X"}})
-	people = append(people, Person{ID: "2", Firstname: "Koko", Lastname: "Doe", Address: &Address{City: "City Y", State: "State Y"}})
-	people = append(people, Person{ID: "3", Firstname: "Francis", Lastname: "Sunday"})
+	// Let's populate the map with initial values
+	people = map[string]Person{
+		"1": Person{ID: "1", Firstname: "Bono", Lastname: "Doe", Address: &Address{City: "City X", State: "State X"}},
+		"2": Person{ID: "2", Firstname: "The Edge", Lastname: "Doe", Address: &Address{City: "City Y", State: "State Y"}},
+		"3": Person{ID: "3", Firstname: "Adam", Lastname: "Doe"},
+		"4": Person{ID: "4", Firstname: "Larry", Lastname: "Doe"},
+	}
 
 	router := mux.NewRouter()
-	router.HandleFunc("/people", GetPeople).Methods("GET")
-	router.HandleFunc("/people/{id}", GetPerson).Methods("GET")
-	router.HandleFunc("/people/{id}", CreatePerson).Methods("POST")
-	router.HandleFunc("/people/{id}", DeletePerson).Methods("DELETE")
+	router.HandleFunc("/people", all).Methods("GET")
+	router.HandleFunc("/people/{id}", findByID).Methods("GET")
+	router.HandleFunc("/people/{id}", store).Methods("PUT")
+	router.HandleFunc("/people/{id}", remove).Methods("DELETE")
 
 	log.Fatal(http.ListenAndServe(":8000", router))
 }


### PR DESCRIPTION
Some refactors, for more idiomatic Go code,

- Using `map` instead of `array`.
- Not exporting internal functions
- Renaming functions
- Using HTTP status codes
- Change POST to PUT, for an idempotent storage operation.

There are more things that could be done, but... ;)
